### PR TITLE
Get Device Token from Parse (event)

### DIFF
--- a/android/example/app.js
+++ b/android/example/app.js
@@ -1,5 +1,8 @@
 var Parse = require('eu.rebelcorp.parse');
 
+Parse.addEventListener("tokenReceived",function(e) {
+			Ti.API.info("::PARSE::tokenReceived::"+JSON.stringify(e.deviceToken));
+	});
 Parse.start();
 
 // Subscribe of unsubscribe to Parse Channels

--- a/android/src/eu/rebelcorp/parse/ParseModule.java
+++ b/android/src/eu/rebelcorp/parse/ParseModule.java
@@ -8,6 +8,8 @@
  */
 package eu.rebelcorp.parse;
 
+import java.util.HashMap;
+
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 
@@ -127,6 +129,13 @@ public class ParseModule extends KrollModule
             public void done(ParseException e) {
                 if (e != null) {
                     Log.e(TAG, "Installation initialization failed: " + e.getMessage());
+                }
+                else
+                {
+                    String deviceToken = (String)ParseInstallation.getCurrentInstallation().get("deviceToken");
+                    HashMap<String, Object> dict = new HashMap<String, Object>();
+                    dict.put("deviceToken",deviceToken);
+                    fireEvent("tokenReceived", dict);
                 }
             }
         });


### PR DESCRIPTION
Add event to receive device token from Parse after initialization (to rely only on Parse, and exclude CloudPush and dependency on ACS, that people require to obtain token)